### PR TITLE
COURSESPLT-13

### DIFF
--- a/courses-portlet-dao/src/main/java/org/jasig/portlet/courses/dao/xml/HttpClientCoursesDaoImpl.java
+++ b/courses-portlet-dao/src/main/java/org/jasig/portlet/courses/dao/xml/HttpClientCoursesDaoImpl.java
@@ -18,7 +18,9 @@
  */
 package org.jasig.portlet.courses.dao.xml;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import javax.portlet.PortletRequest;
 
@@ -41,11 +43,30 @@ import org.springframework.web.client.RestTemplate;
  * @version $Revision$
  */
 public class HttpClientCoursesDaoImpl implements ICoursesDao {
+    public static final String PROPERTY_KEY_TERMCODE = "#TERMCODE#";
 
-    private String urlFormat = "http://localhost:8180/jasig-courses-integration/course-summary";
+    private String termsUrlFormat = null;
 
-    public void setUrlFormat(String urlFormat) {
-        this.urlFormat = urlFormat;
+    public void setTermsUrlFormat(String urlFormat) {
+        this.termsUrlFormat = urlFormat;
+    }
+
+    private Map<String,String> termsUrlParams = new HashMap<String,String>();
+
+    public void setTermsUrlParams(Map<String,String> params) {
+        this.termsUrlParams = params;
+    }
+
+    private String coursesUrlFormat = null;
+
+    public void setCoursesUrlFormat(String urlFormat) {
+        this.coursesUrlFormat = urlFormat;
+    }
+
+    private Map<String,String> coursesUrlParams = new HashMap<String,String>();
+
+    public void setCoursesUrlParams(Map<String,String> params) {
+        this.coursesUrlParams = params;
     }
 
     private String usernameKey = "user.login.id";
@@ -62,36 +83,36 @@ public class HttpClientCoursesDaoImpl implements ICoursesDao {
     
     private RestTemplate restTemplate;
 
-    @Autowired(required = true)
     public void setRestTemplate(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 
     @Override
     public TermList getTermList(PortletRequest request) {
-        final TermsAndCourses termsAndCourses = this.getTermsAndCourses(request);
-        return termsAndCourses.getTermList();
+        Map<String,String> params = createParameters(request, termsUrlParams, null);
+        return getTermsAndCourses(request,termsUrlFormat,params).getTermList();
     }
 
     @Override
     public CoursesByTerm getCoursesByTerm(PortletRequest request, String termCode) {
-        final TermsAndCourses termsAndCourses = this.getTermsAndCourses(request);
-        return termsAndCourses.getCoursesByTerm(termCode);
+        Properties props =  new Properties();
+        props.setProperty(PROPERTY_KEY_TERMCODE,termCode);
+        Map<String,String> params = createParameters(request,coursesUrlParams,props);
+        return getTermsAndCourses(request,coursesUrlFormat,params).getCoursesByTerm(termCode);
     }
     
     /**
-     * Get terms and courses for the current user  
+     * Get terms and courses for the current user
      */
-    protected TermsAndCourses getTermsAndCourses(PortletRequest request) {
+    protected TermsAndCourses getTermsAndCourses(PortletRequest request,String url, Map<String,String> params) {
         HttpEntity<?> requestEntity = getRequestEntity(request);
-
         HttpEntity<TermsAndCourses> response = restTemplate.exchange(
-                urlFormat, HttpMethod.GET, requestEntity,
-                TermsAndCourses.class);
-        
+                url, HttpMethod.GET, requestEntity,
+                TermsAndCourses.class,params);
+
         return response.getBody();
     }
-    
+
     /**
      * Get a request entity prepared for basic authentication.
      */
@@ -100,7 +121,7 @@ public class HttpClientCoursesDaoImpl implements ICoursesDao {
         Map<String,String> userInfo = (Map<String,String>) request.getAttribute(PortletRequest.USER_INFO);
         String username = userInfo.get(this.usernameKey);
         String password = userInfo.get(this.passwordKey);
-        
+
         HttpHeaders requestHeaders = new HttpHeaders();
         String authString = username.concat(":").concat(password);
         String encodedAuthString = new Base64().encodeToString(authString.getBytes());
@@ -109,4 +130,18 @@ public class HttpClientCoursesDaoImpl implements ICoursesDao {
         return requestEntity;
     }
 
+    protected Map<String,String> createParameters(PortletRequest request,Map<String,String> params,Properties props) {
+        Map<String,String> userInfo = (Map<String,String>) request.getAttribute(PortletRequest.USER_INFO);
+        Map<String,String> result = new HashMap<String,String>();
+        if(props == null) props = new Properties();
+
+        for(String key : params.keySet()) {
+            if(PROPERTY_KEY_TERMCODE.equals(params.get(key))) {
+                result.put(key,props.getProperty(PROPERTY_KEY_TERMCODE));
+                continue;
+            }
+            result.put(key,userInfo.get(params.get(key)));
+        }
+        return result;
+    }
 }

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -66,10 +66,21 @@
     </bean>
         
     <util:list id="courseDaos">
-        <bean class="org.jasig.portlet.courses.dao.xml.MockCoursesDaoImpl"
-            p:mockData="classpath:/mock-data/mock-course-summary.xml"/>
-        <bean class="org.jasig.portlet.courses.dao.xml.HttpClientCoursesDaoImpl"
-            p:restTemplate-ref="restTemplate"/>
+        <bean class="org.jasig.portlet.courses.dao.xml.MockCoursesDaoImpl" p:mockData="classpath:/mock-data/mock-course-summary.xml"/>
+        <!-- Uncomment this bean to retrieve the terms and course data from an HTTP XML resource
+             The XML is expected to follow the same schema as the mock-course-summary.xml file. -->
+
+        <!-- <bean class="org.jasig.portlet.courses.dao.xml.HttpClientCoursesDaoImpl" p:restTemplate-ref="restTemplate">
+            <property name="termsUrlFormat" value="http://localhost/CoursesPortletTermsFeed.xml"/>
+            <property name="coursesUrlFormat" value="http://localhost/CoursesPortletCoursesFeed_{user.id}_{term.code}.xml"/>
+            <property name="coursesUrlParams">
+                <util:map key-type="java.lang.String" value-type="java.lang.String">
+                    <entry key="user.id" value="user.login.id"/>
+                    <entry key="term.code" value="#TERMCODE#"/>
+                </util:map>
+            </property>
+        </bean> -->
+
     </util:list>
 
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean"


### PR DESCRIPTION
Modify the HttpClientCoursesDaoImpl to be able to retrieve term and course information from 2 separate XML feeds. Parameter maps can be supplied to either URL for performing substring replacement within the URL with user attributes or with predefined properties (currently only term code is supported).
