### PR TITLE
ci: align Java to fleet floor (11) — CI matrix + pom source/target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,15 +39,14 @@ jobs:
           - temurin
           - zulu
         java-version:
-          - 17
-          - 21
+          - 11
         include:
           - platform: windows-latest
             java-distribution: adopt-hotspot
-            java-version: 17
+            java-version: 11
           - platform: macos-latest
             java-distribution: adopt-hotspot
-            java-version: 17
+            java-version: 11
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 5
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
     <slf4j.version>2.0.17</slf4j.version>
     <bouncycastle.version>1.84</bouncycastle.version>
 
-    <project.build.sourceVersion>17</project.build.sourceVersion>
-    <project.build.targetVersion>17</project.build.targetVersion>
+    <project.build.sourceVersion>11</project.build.sourceVersion>
+    <project.build.targetVersion>11</project.build.targetVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
## Summary

CoursesPortlet was the only portlet in the fleet targeting Java 17/21 — both in CI matrix and in the pom's source/target. PR #88 (June 2025) bumped both ahead of any fleet-wide migration. Every other portlet (and uPortal core) targets Java 11 — the workspace floor and what adopters deploy on (Tomcat 8.5/9).

This PR realigns to Java 11 in both places.

## Why

PRs that work on Java 11 get blocked here on Java-17-only stricter compile checks. Concrete example: PR #44 (joda-time) currently fails because of a try/catch on an unreachable \`IOException\` that javac stopped accepting in Java 17 — pre-existing source code, not the dep bump's fault.

A first attempt that only fixed CI failed because the pom still said \`<project.build.targetVersion>17</project.build.targetVersion>\` — javac on Java 11 doesn't recognize \`-target 17\`. So both ends had to move together.

## Changes

- \`.github/workflows/CI.yml\`: \`java-version\` 17/21 → 11 across the ubuntu matrix and the windows/macos \`include:\` slots. Same shape as basiclti-portlet, BookmarksPortlet, CalendarPortlet, FeedbackPortlet, JasigWidgetPortlets, NewsReaderPortlet, SimpleContentPortlet, WebproxyPortlet.
- \`pom.xml\`: \`<project.build.sourceVersion>\` / \`<project.build.targetVersion>\` 17 → 11.

## Out of scope (separate cleanup)

This pom still inherits from the old \`org.jasig.parent:jasig-parent:34\` parent, while every other portlet has long since migrated to \`org.jasig.portlet:uportal-portlet-parent:48\`. The migration would let us drop a lot of the redundant \`<dependencyManagement>\` entries currently in this pom (logback, commons-codec, commons-io, etc.). That's a larger PR worth doing once the immediate release prep is done.

## Notes

- A fleet-wide Java 17 migration would re-add 17 here in lockstep with the rest. Until that's scheduled, single-repo floor bumps shouldn't lead. Same reasoning as closing NotificationPortlet#657 and NewsReaderPortlet#403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)