### PR TITLE
chore: upgrade joda-time 2.1 → 2.14.2 and adapt printTo callsite

### DIFF
--- a/courses-portlet-api/src/main/java/org/jasig/portlet/courses/model/xml/CourseMeetingWrapper.java
+++ b/courses-portlet-api/src/main/java/org/jasig/portlet/courses/model/xml/CourseMeetingWrapper.java
@@ -18,23 +18,19 @@
  */
 package org.jasig.portlet.courses.model.xml;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.joda.time.LocalTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Adds base functionality to the {@link CourseMeeting} object
- * 
+ *
  * @author Drew Wills
  */
 public abstract class CourseMeetingWrapper {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
-    
+
     private static final DateTimeFormatter SHORT_TIME_FORMAT = DateTimeFormat.shortTime();
     
     public abstract LocalTime getStartTime();
@@ -55,15 +51,10 @@ public abstract class CourseMeetingWrapper {
          * pick-and-choose which data they provide. 
          */
         if (startTime != null) {
-            try {
-                SHORT_TIME_FORMAT.printTo(rslt, startTime);
-                if (endTime != null) {
-                    rslt.append(" - ");
-                    SHORT_TIME_FORMAT.printTo(rslt, endTime);
-                }
-            }
-            catch (IOException e) {
-                logger.info("Failed to generate formatted string for course.startTime=" + startTime + " and course.endTime=" + endTime, e);
+            SHORT_TIME_FORMAT.printTo(rslt, startTime);
+            if (endTime != null) {
+                rslt.append(" - ");
+                SHORT_TIME_FORMAT.printTo(rslt, endTime);
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.1</version>
+        <version>2.14.2</version>
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>


### PR DESCRIPTION
## Summary

Picks up the long-stale Renovate joda-time bump (#44, open since 2022) by handling the source-level break it surfaces. Closes #44.

## Why #44 couldn't auto-merge

joda-time 2.4 (June 2014) changed `DateTimeFormatter.printTo(StringBuilder, ...)` to no longer declare `IOException` — a `StringBuilder.append` can't actually fail for I/O, and the `Appendable` overload was kept for callers that legitimately need to handle one. With 2.14.2 in place, our existing `catch (IOException e)` block in `CourseMeetingWrapper.getFormattedMeetingTime()` becomes unreachable, which the Java compiler rejects (`exception java.io.IOException is never thrown in body of corresponding try statement`).

Renovate's PR was a pure pom bump and didn't touch the source, so it's been failing CI for years. Picking it up now via a hand-tailored PR.

## Changes

`pom.xml`:
- `joda-time` 2.1 → 2.14.2.

`courses-portlet-api/.../CourseMeetingWrapper.java`:
- Drop the `try { ... } catch (IOException e) { logger.info(...) }` wrapper around the two `SHORT_TIME_FORMAT.printTo()` calls — the catch is now unreachable.
- Drop the unused `import java.io.IOException`.
- Drop the unused `protected final Logger logger = LoggerFactory.getLogger(getClass())` field — it was only used by the removed catch block.

## Risk audit

Verified joda-time usage across the codebase before merging:

```
$ grep -rE "import org\.joda\.time" courses-portlet-{api,dao,webapp}/src
DateMidnight, DateTime, DateTimeConstants, DateTimeZone,
DateTimeFormat, DateTimeFormatter, LocalTime, Minutes
```

All stable APIs that didn't change between 2.1 and 2.14.2. `DateMidnight` is deprecated since 2.4 but is still present in 2.14.2; left as-is — separate cleanup if/when we want to migrate to `LocalDate.toDateTimeAtStartOfDay()`.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn license:check` — green
- [x] All 4 unit tests pass
- [x] Source audit: only one `printTo(StringBuilder, ...)` callsite in the codebase (the one fixed)
- [ ] CI on Java 11 matrix
- [ ] Once merged: close Renovate #44 (will auto-close on conflict resolution)
