### PR TITLE
chore: bump parent v49 → v50 for plexus-archiver CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>49</version>
+    <version>50</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Bumps to [uportal-portlet-parent:50](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-50), which patches **CVE-2023-37460** (plexus-archiver Arbitrary File Creation in AbstractUnArchiver, CVSS 8.1 HIGH) by bumping its bundled `maven-war-plugin` 3.4.0 → 3.5.1 (which carries plexus-archiver 4.10.4, patched).

Real-world risk for portlet builds is low — we use plexus-archiver to *create* WARs, not extract untrusted archives — but the parent shouldn't ship a known-vulnerable transitive by default.

## Test plan

- [x] `mvn clean install license:check -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix