### PR TITLE
chore: bump parent v50 -> v51 and migrate commons-lang -> commons-lang3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,9 +16,12 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
+  AntLR under BSD License
   AOP alliance under Public Domain
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons FileUpload under Apache License, Version 2.0
+  Apache Commons Lang under Apache-2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   Apache WSS4J under The Apache Software License, Version 2.0
@@ -28,20 +31,22 @@ This project includes:
   Bouncy Castle Provider under Bouncy Castle Licence
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
-  Commons FileUpload under The Apache Software License, Version 2.0
   Commons IO under The Apache Software License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
-  Commons Logging under The Apache Software License, Version 2.0
+  commons-collections under Apache License, Version 2.0
   CoursePortlet under Apache License Version 2.0
   CoursePortlet - API under Apache License Version 2.0
   CoursePortlet - Data Access Objects for SIS/LMS integration under Apache License Version 2.0
   CoursePortlet - Webapp under Apache License Version 2.0
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
+  dom4j under BSD License
   ehcache under The Apache Software License, Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   Hamcrest Core under New BSD License
+  Hibernate Core under GNU Lesser General Public License
   Jackson module: Old JAXB Annotations (javax.xml.bind) under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
@@ -51,21 +56,23 @@ This project includes:
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   Java Portlet Specification V2.0 under Commons Development and Distribution License, Version 1.0
+  Java Servlet API under CDDL + GPLv2 with classpath exception
+  Java Transaction API under Commons Development and Distribution License, Version 1.0
   java-support under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   JavaMail 1.4 under The Apache Software License, Version 2.0
   javax.annotation API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda time under Apache 2
+  JCL 1.2 implemented over SLF4J under Apache-2.0
+  Joda-Time under Apache License, Version 2.0
   Joda-Time JSP tags support under Apache 2
   jstl under Commons Development and Distribution License, Version 1.0
-  JUL to SLF4J bridge under MIT License
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   mockito-core under The MIT License
   Objenesis under Apache License, Version 2.0
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
@@ -90,8 +97,7 @@ This project includes:
   Resource Server Content under Apache License Version 2.0
   Resource Server Core under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under The Apache Software License, Version 2.0
   Spring Beans under The Apache Software License, Version 2.0
   Spring Context under The Apache Software License, Version 2.0
@@ -99,14 +105,14 @@ This project includes:
   Spring Core under The Apache Software License, Version 2.0
   Spring Expression Language (SpEL) under The Apache Software License, Version 2.0
   Spring JDBC under The Apache Software License, Version 2.0
-  Spring Portlet WebMVC Contributions under Apache License Version 2.0
+  Spring Object/XML Marshalling under The Apache Software License, Version 2.0
+  Spring Portlet WebMVC Contributions under Apache License, Version 2.0
   Spring TestContext Framework under The Apache Software License, Version 2.0
   Spring Transaction under The Apache Software License, Version 2.0
   Spring Web under The Apache Software License, Version 2.0
   Spring Web MVC under The Apache Software License, Version 2.0
   Spring Web Portlet under The Apache Software License, Version 2.0
   Spring WS Core under The Apache Software License, Version 2.0
-  spring-oxm under The Apache Software License, Version 2.0
   spring-security-core under The Apache Software License, Version 2.0
   spring-ws-security under Apache License, Version 2.0
   spring-xml under Apache License, Version 2.0
@@ -115,5 +121,6 @@ This project includes:
   Streaming API for XML under Sun Binary Code License
   Woodstox under The Apache Software License, Version 2.0
   WSDL4J under CPL
+  XML Commons External Components XML APIs under The Apache Software License, Version 2.0
   XMLTooling-J under Apache 2
 

--- a/courses-portlet-api/pom.xml
+++ b/courses-portlet-api/pom.xml
@@ -33,8 +33,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/courses-portlet-api/src/main/java/org/jasig/portlet/degreeprogress/model/StudentCourseRegistration.java
+++ b/courses-portlet-api/src/main/java/org/jasig/portlet/degreeprogress/model/StudentCourseRegistration.java
@@ -18,8 +18,8 @@
  */
 package org.jasig.portlet.degreeprogress.model;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.jasig.portlet.degreeprogress.model.xml.Course;
 import org.jasig.portlet.degreeprogress.model.xml.Grade;
 import org.jasig.portlet.degreeprogress.model.xml.Semester;

--- a/courses-portlet-dao/src/main/java/org/jasig/portlet/courses/dao/xml/SecureRequestCredentials.java
+++ b/courses-portlet-dao/src/main/java/org/jasig/portlet/courses/dao/xml/SecureRequestCredentials.java
@@ -36,7 +36,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * Holds a username and password in a secure manner. The intent is not to protect from in memory attacks as calling {@link #getPassword()}

--- a/courses-portlet-webapp/pom.xml
+++ b/courses-portlet-webapp/pom.xml
@@ -37,8 +37,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/courses-portlet-webapp/src/main/java/org/jasig/portlet/courses/mvc/wrapper/CourseSectionMeetingWrapper.java
+++ b/courses-portlet-webapp/src/main/java/org/jasig/portlet/courses/mvc/wrapper/CourseSectionMeetingWrapper.java
@@ -18,7 +18,7 @@
  */
 package org.jasig.portlet.courses.mvc.wrapper;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.courses.model.xml.CourseMeeting;
 import org.jasig.portlet.courses.model.xml.CourseSection;
 import org.jasig.portlet.courses.service.IURLService;

--- a/courses-portlet-webapp/src/main/java/org/jasig/portlet/degreeprogress/mvc/portlet/DegreeProgressController.java
+++ b/courses-portlet-webapp/src/main/java/org/jasig/portlet/degreeprogress/mvc/portlet/DegreeProgressController.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.courses.dao.ICoursesDao;
 import org.jasig.portlet.degreeprogress.dao.IDegreeProgramDao;
 import org.jasig.portlet.degreeprogress.dao.IDegreeProgressDao;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>50</version>
+    <version>51</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Release-prep PR for CoursesPortlet 2.1.1, aligning with the fleet-wide v51 + lang3 wave.

Supersedes #110 (which was the bare parent bump from Renovate, but would have failed CI without the source migration).

## Summary

Two commits, both keep master green:

1. **Parent v50 -> v51 + commons-lang -> commons-lang3**: parent v51 dropped legacy `commons-lang` from `dependencyManagement` (CVE-2025-48924 close-out). This repo declares `commons-lang` directly in two submodule poms (`courses-portlet-api`, `courses-portlet-webapp`) and uses it from 4 source files (`StudentCourseRegistration`, `SecureRequestCredentials`, `CourseSectionMeetingWrapper`, `DegreeProgressController`). All three needed updating. lang3 is API-compatible for the StringUtils, RandomStringUtils, builder.ToStringBuilder, builder.ToStringStyle classes used here.
2. **Regenerate NOTICE**: aligns with the post-v51 dep tree.

The earlier v49 -> v50 bump (CVE-2023-37460 plexus-archiver) shipped via #109 and is the merge base here.

## Deferred

- #106 (`spring-ws-security` v5 major bump) and #107 (`jaxb2basics` major bump) are intentionally left open — both are major version jumps that need separate review and are not blockers for 2.1.1.

## Test plan

- [x] `mvn -B clean install` passes locally on Java 11 (4-module reactor green)
- [x] `mvn notice:check` passes
- [x] `mvn license:check` passes
- [ ] CI green
- [ ] Post-merge: `mvn release:clean release:prepare release:perform` for 2.1.1