### PR TITLE
chore: regenerate per-submodule NOTICE files for parent v51 + lang3

### DIFF
--- a/courses-portlet-api/NOTICE
+++ b/courses-portlet-api/NOTICE
@@ -16,14 +16,14 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
-  Commons Lang under The Apache Software License, Version 2.0
+  Apache Commons Lang under Apache-2.0
   CoursePortlet - API under Apache License Version 2.0
   Hamcrest Core under New BSD License
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   javax.annotation API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  Joda time under Apache 2
+  Joda-Time under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
 

--- a/courses-portlet-dao/NOTICE
+++ b/courses-portlet-dao/NOTICE
@@ -17,10 +17,10 @@ under the License.
 
 This project includes:
   AOP alliance under Public Domain
-  Apache Commons Codec under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
-  Commons Lang under The Apache Software License, Version 2.0
   CoursePortlet - API under Apache License Version 2.0
   CoursePortlet - Data Access Objects for SIS/LMS integration under Apache License Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
@@ -28,20 +28,20 @@ This project includes:
   Jakarta Activation under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   Java Portlet Specification V2.0 under Commons Development and Distribution License, Version 1.0
+  Java Servlet API under CDDL + GPLv2 with classpath exception
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   javax.annotation API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda time under Apache 2
-  JUL to SLF4J bridge under MIT License
+  JCL 1.2 implemented over SLF4J under Apache-2.0
+  Joda-Time under Apache License, Version 2.0
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
+  Log4j Implemented Over SLF4J under Apache-2.0
   mockito-core under The MIT License
   Objenesis under Apache License, Version 2.0
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under The Apache Software License, Version 2.0
   Spring Beans under The Apache Software License, Version 2.0
   Spring Context under The Apache Software License, Version 2.0

--- a/courses-portlet-webapp/NOTICE
+++ b/courses-portlet-webapp/NOTICE
@@ -16,9 +16,12 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
+  AntLR under BSD License
   AOP alliance under Public Domain
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons FileUpload under Apache License, Version 2.0
+  Apache Commons Lang under Apache-2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   Apache WSS4J under The Apache Software License, Version 2.0
@@ -28,19 +31,21 @@ This project includes:
   Bouncy Castle Provider under Bouncy Castle Licence
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
-  Commons FileUpload under The Apache Software License, Version 2.0
   Commons IO under The Apache Software License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
-  Commons Logging under The Apache Software License, Version 2.0
+  commons-collections under Apache License, Version 2.0
   CoursePortlet - API under Apache License Version 2.0
   CoursePortlet - Data Access Objects for SIS/LMS integration under Apache License Version 2.0
   CoursePortlet - Webapp under Apache License Version 2.0
   Cryptacular Library under Apache 2 or GNU Lesser General Public License
+  dom4j under BSD License
   ehcache under The Apache Software License, Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   Hamcrest Core under New BSD License
+  Hibernate Core under GNU Lesser General Public License
   Jackson module: Old JAXB Annotations (javax.xml.bind) under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
@@ -50,21 +55,23 @@ This project includes:
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
   Java Portlet Specification V2.0 under Commons Development and Distribution License, Version 1.0
+  Java Servlet API under CDDL + GPLv2 with classpath exception
+  Java Transaction API under Commons Development and Distribution License, Version 1.0
   java-support under The Apache Software License, Version 2.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   JavaMail 1.4 under The Apache Software License, Version 2.0
   javax.annotation API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda time under Apache 2
+  JCL 1.2 implemented over SLF4J under Apache-2.0
+  Joda-Time under Apache License, Version 2.0
   Joda-Time JSP tags support under Apache 2
   jstl under Commons Development and Distribution License, Version 1.0
-  JUL to SLF4J bridge under MIT License
+  JUL to SLF4J bridge under MIT
   JUnit under Eclipse Public License 1.0
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   mockito-core under The MIT License
   Objenesis under Apache License, Version 2.0
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
@@ -89,8 +96,7 @@ This project includes:
   Resource Server Content under Apache License Version 2.0
   Resource Server Core under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under The Apache Software License, Version 2.0
   Spring Beans under The Apache Software License, Version 2.0
   Spring Context under The Apache Software License, Version 2.0
@@ -98,14 +104,14 @@ This project includes:
   Spring Core under The Apache Software License, Version 2.0
   Spring Expression Language (SpEL) under The Apache Software License, Version 2.0
   Spring JDBC under The Apache Software License, Version 2.0
-  Spring Portlet WebMVC Contributions under Apache License Version 2.0
+  Spring Object/XML Marshalling under The Apache Software License, Version 2.0
+  Spring Portlet WebMVC Contributions under Apache License, Version 2.0
   Spring TestContext Framework under The Apache Software License, Version 2.0
   Spring Transaction under The Apache Software License, Version 2.0
   Spring Web under The Apache Software License, Version 2.0
   Spring Web MVC under The Apache Software License, Version 2.0
   Spring Web Portlet under The Apache Software License, Version 2.0
   Spring WS Core under The Apache Software License, Version 2.0
-  spring-oxm under The Apache Software License, Version 2.0
   spring-security-core under The Apache Software License, Version 2.0
   spring-ws-security under Apache License, Version 2.0
   spring-xml under Apache License, Version 2.0
@@ -114,5 +120,6 @@ This project includes:
   Streaming API for XML under Sun Binary Code License
   Woodstox under The Apache Software License, Version 2.0
   WSDL4J under CPL
+  XML Commons External Components XML APIs under The Apache Software License, Version 2.0
   XMLTooling-J under Apache 2
 


### PR DESCRIPTION
Follow-up to #111 — that PR regenerated the **root** NOTICE for the parent v51 + commons-lang3 work, but missed the per-submodule NOTICEs. Running \`mvn notice:check\` on current master fails on \`courses-portlet-api\`, which would block \`release:prepare\` for 2.1.1.

This PR brings the three submodule NOTICEs in sync with their actual dep trees post-v51 (license-name normalization: \"Apache Commons Lang under Apache-2.0\" vs the older \"Commons Lang under The Apache Software License, Version 2.0\", same for Joda-Time and SLF4J).

## Test plan

- [x] \`mvn -B notice:check\` passes on all 4 reactor modules locally
- [ ] CI green
- [ ] After merge: \`mvn release:clean release:prepare release:perform\` for 2.1.1