### PR TITLE
refactor: drop legacy rs/jquery + drop resource-server-content overlay

### DIFF
--- a/courses-portlet-webapp/pom.xml
+++ b/courses-portlet-webapp/pom.xml
@@ -117,11 +117,6 @@
             <artifactId>resource-server-utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jasig.resourceserver</groupId>
-            <artifactId>resource-server-content</artifactId>
-            <type>war</type>
-        </dependency>
-        <dependency>
             <groupId>org.jasig.springframework</groupId>
             <artifactId>spring-webmvc-portlet-contrib</artifactId>
         </dependency>
@@ -227,21 +222,6 @@
                       </configuration>
                   </execution>
               </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-war-plugin</artifactId>
-            <configuration>
-              <overlays>
-                  <overlay>
-                      <groupId>org.jasig.resourceserver</groupId>
-                      <artifactId>resource-server-content</artifactId>
-                      <includes>
-                          <include>rs/jquery/1.6.1/</include>
-                          <include>rs/jqueryui/1.8.13/</include>
-                      </includes>
-                  </overlay>
-              </overlays>
-            </configuration>
           </plugin>
         </plugins>
     </build>

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/degreeprogress/whatIf.jsp
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/degreeprogress/whatIf.jsp
@@ -21,7 +21,6 @@
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 <portlet:renderURL var="reportUrl"/>
 <c:set var="n"><portlet:namespace/></c:set>
-<script type="text/javascript" src="<rs:resourceURL value="/rs/jquery/1.4.2/jquery-1.4.2.min.js"/>"></script>
 
 <link rel="stylesheet" type="text/css" href="<c:url value="/css/degree-progress.css"/>"></link>
 <style type="text/css">

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/final-grades/grades-jQM.jsp
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/final-grades/grades-jQM.jsp
@@ -38,7 +38,7 @@
                 htmlEscape="false"
                 javaScriptEscape="false" />
 <script type="text/javascript" language="javascript">
-  <rs:compressJs>(function($) {
+  (function($) {
     $(function() {
       coursesPortlet.updateGradesTermHandler({
         termEl: $('#${n}_termPicker'),
@@ -50,5 +50,4 @@
       });
     });
   })(coursesPortlet.jQuery);
-  </rs:compressJs>
 </script>

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/final-grades/grades.jsp
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/final-grades/grades.jsp
@@ -42,7 +42,7 @@
                 htmlEscape="false"
                 javaScriptEscape="false" />
 <script type="text/javascript" language="javascript">
-  <rs:compressJs>(function($) {
+  (function($) {
     $(function() {
       coursesPortlet.updateGradesTermHandler({
         termEl: $('#${n}_termPicker'),
@@ -54,5 +54,4 @@
       });
     });
   })(coursesPortlet.jQuery);
-  </rs:compressJs>
 </script>

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/mycourses/grades-jQM.jsp
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/mycourses/grades-jQM.jsp
@@ -77,7 +77,6 @@
 <portlet:resourceURL var="gradesCourseListUrl" id="gradesUpdate" />
 <spring:message var="errorMessage" code="grades.unavailable" htmlEscape="false" javaScriptEscape="false" />
 <script type="text/javascript" language="javascript">
-<rs:compressJs>
 (function($) {
     $(function() {
         coursesPortlet.updateGradesTermHandler({
@@ -91,5 +90,4 @@
         });
     });    
 })(coursesPortlet.jQuery);
-</rs:compressJs>
 </script>

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/mycourses/grades.jsp
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/mycourses/grades.jsp
@@ -84,7 +84,7 @@
 <spring:message var="errorMessage" code="grades.unavailable"
 	htmlEscape="false" javaScriptEscape="false" />
 <script type="text/javascript" language="javascript">
-	<rs:compressJs>(function($) {
+	(function($) {
 		$(function() {
 			coursesPortlet.updateGradesTermHandler({
 				termSelector : '#${n}_termPicker',
@@ -97,5 +97,4 @@
 			});
 		});
 	})(coursesPortlet.jQuery);
-	</rs:compressJs>
 </script>

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/myuwcourses/grades-jQM.jsp
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/myuwcourses/grades-jQM.jsp
@@ -77,7 +77,6 @@
 <portlet:resourceURL var="gradesCourseListUrl" id="gradesUpdate" />
 <spring:message code="grades.unavailable" arguments="${portletSessionScope.helpDeskURL}" htmlEscape="false" javaScriptEscape="false" />
 <script type="text/javascript" language="javascript">
-<rs:compressJs>
 (function($) {
     $(function() {
         coursesPortlet.updateGradesTermHandler({
@@ -91,5 +90,4 @@
         });
     });    
 })(coursesPortlet.jQuery);
-</rs:compressJs>
 </script>

--- a/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/myuwcourses/grades.jsp
+++ b/courses-portlet-webapp/src/main/webapp/WEB-INF/jsp/myuwcourses/grades.jsp
@@ -83,7 +83,7 @@
 <portlet:resourceURL var="gradesCourseListUrl" id="gradesUpdate" />
 <spring:message code="grades.unavailable" arguments="${portletSessionScope.helpDeskURL}" htmlEscape="false" javaScriptEscape="false" />
 <script type="text/javascript" language="javascript">
-	<rs:compressJs>(function($) {
+	(function($) {
 		$(function() {
 			coursesPortlet.updateGradesTermHandler({
 				termSelector : '#${n}_termPicker',
@@ -96,5 +96,4 @@
 			});
 		});
 	})(coursesPortlet.jQuery);
-	</rs:compressJs>
 </script>

--- a/courses-portlet-webapp/src/main/webapp/resources.xml
+++ b/courses-portlet-webapp/src/main/webapp/resources.xml
@@ -24,12 +24,11 @@
 
   <css>css/uwCoursesPortlet.css</css>
   <css>css/jquery.timetable.css</css>
-    
-  <js included="plain" resource="true">/rs/jquery/1.9.1/jquery-1.9.1.js</js>
-  <js included="aggregated" resource="true">/rs/jquery/1.9.1/jquery-1.9.1.min.js</js>
-  
-  <js included="plain" resource="true">/rs/jqueryui/1.8.13/jquery-ui-1.8.13.js</js>
-  <js included="aggregated" resource="true">/rs/jqueryui/1.8.13/jquery-ui-1.8.13.min.js</js>
+
+  <!-- jQuery + jQuery UI come from the bedrock skin (jquery 4.x + migrate,
+       jquery-ui 1.14.x). CoursesPortlet's own jquery 1.9.1 / jquery-ui
+       1.8.13 overrides removed 2026-05-06 to close known XSS CVEs in
+       1.x. -->
 
   <!-- Order is important here, the log script needs to be the first thing followed by the debug toggle -->
   <js>js-lib/jquery.log.js</js>

--- a/pom.xml
+++ b/pom.xml
@@ -240,12 +240,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.jasig.resourceserver</groupId>
-        <artifactId>resource-server-content</artifactId>
-        <version>${resource-server.version}</version>
-        <type>war</type>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Summary

Three commits — release-plugin commits from a prior 2.1.1 release cycle that didn't get pushed, plus the actual work:

1. `da39d63` — release plugin prep for 2.1.1 (already-released)
2. `0453e6f` — release plugin post-2.1.1 SNAPSHOT bump
3. **`677110b`** (prior) — drop legacy rs/jquery loads + retire `<rs:compressJs>` taglib wrappers; the source-side consolidation.
4. **`9df8b28`** (new) — drop the `resource-server-content` WAR overlay (dep + maven-war-plugin extract). The overlay was unpacking lodash 4.17.4 (4 CVEs), underscore, backbone, modernizr, normalize, and jquery-plugins into the WAR for nothing, plus an explicit extract of `rs/jquery/1.6.1/` and `rs/jqueryui/1.8.13/` — none referenced after `677110b`.

## Why this is safe

- `grep -rEn '/CoursesPortlet/rs/' courses-portlet-webapp/src/` returns no matches after `677110b`.
- jQuery is loaded by uPortal core's chrome via `/resource-server/webjars/jquery/...`.

## Test plan

- [ ] `mvn clean install -DskipTests` builds (verified locally on Java 11)
- [ ] WAR has no `rs/` directory (verified)
- [ ] Smoke: `/p/courses/?pCm=view` and admin views render without missing-resource errors