### PR TITLE
chore(deps): remove unused spring-ws-security, portlet-ws-util, bounc…

### DIFF
--- a/courses-portlet-webapp/pom.xml
+++ b/courses-portlet-webapp/pom.xml
@@ -65,10 +65,6 @@
             <artifactId>portlet-mvc-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jasig.portlet.utils</groupId>
-            <artifactId>portlet-ws-util</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
         </dependency>
@@ -99,14 +95,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc-portlet</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.ws</groupId>
-            <artifactId>spring-ws-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
     <jaxb2basics.version>0.13.1</jaxb2basics.version>
     <resource-server.version>1.5.3</resource-server.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -127,19 +126,7 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.jasig.portlet.utils</groupId>
-        <artifactId>portlet-ws-util</artifactId>
-        <version>1.1.3</version>
-        <exclusions>
-          <!-- spring-ws-core pulls commons-logging (banned by parent;
-               jcl-over-slf4j bridges JCL calls to slf4j). -->
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
+
       <dependency>
         <groupId>org.jasig.springframework</groupId>
         <artifactId>spring-webmvc-portlet-contrib</artifactId>
@@ -201,29 +188,7 @@
         <artifactId>spring-test</artifactId>
         <version>${spring.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.springframework.ws</groupId>
-        <artifactId>spring-ws-security</artifactId>
-        <version>2.4.7.RELEASE</version>
-        <exclusions>
-          <!-- bcprov-jdk15on is the deprecated/EOL jdk15 line; we pin
-               bcprov-jdk18on (modern Java 8+ artifact) below. -->
-          <exclusion>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-          </exclusion>
-          <!-- spring-xml + wss4j pull commons-logging (banned by parent). -->
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk18on</artifactId>
-        <version>${bouncycastle.version}</version>
-      </dependency>
+
       <dependency>
         <groupId>taglibs</groupId>
         <artifactId>standard</artifactId>


### PR DESCRIPTION
…ycastle

Remove three vestigial dependencies that are not referenced anywhere in the source code or Spring XML configuration:

- org.springframework.ws:spring-ws-security (2.4.7.RELEASE)
- org.jasig.portlet.utils:portlet-ws-util (1.1.3)
- org.bouncycastle:bcprov-jdk18on (1.84)

The portlet uses RestTemplate for all external data access; no SOAP or WS-Security integration is wired up. BouncyCastle was only present to replace a deprecated transitive (bcprov-jdk15on) pulled by spring-ws-security — with that gone, BC has no purpose here.

Removing these eliminates a version-skew risk: Renovate proposed bumping spring-ws-security to 5.x (Spring 6 / Jakarta EE), which would compile but explode at runtime against the Spring 3.2 framework this portlet still uses.